### PR TITLE
Added support for module expressions

### DIFF
--- a/tasks/jspm.js
+++ b/tasks/jspm.js
@@ -1,48 +1,40 @@
 "use strict";
 
 module.exports = function (grunt) {
-    var eachAsync = require("each-async");
+	var eachAsync = require("each-async");
 
-    // Setup JSPM
-    var jspm = require("jspm");
-    jspm.setPackagePath(".");
+	// Setup JSPM
+	var jspm = require("jspm");
+	jspm.setPackagePath(".");
 
-    // Geth the JSPM baseURL from package.json
-    var getBaseUrl = function () {
-        var pkgJson = grunt.file.readJSON("package.json");
+	// Geth the JSPM baseURL from package.json
+	var getBaseUrl = function () {
+		var pkgJson = grunt.file.readJSON("package.json");
 
-        if (pkgJson.jspm && pkgJson.jspm.directories && pkgJson.jspm.directories.baseURL) {
-            return pkgJson.jspm.directories.baseURL;
-        }
+		if (pkgJson.jspm && pkgJson.jspm.directories && pkgJson.jspm.directories.baseURL) {
+			return pkgJson.jspm.directories.baseURL;
+		}
 
-        return "";
-    };
+		return "";
+	};
 
 	grunt.registerMultiTask("jspm", "Bundle JSPM", function () {
-        var options = this.options({
-            sfx: true,
-            mangle: true,
-            minify: true
-        });
+		var options = this.options({
+			sfx: true,
+			mangle: true,
+			minify: true
+		});
 
-        var bundle = options.sfx ? "bundleSFX" : "bundle";
+		var bundle = options.sfx ? "bundleSFX" : "bundle";
 
-        // JSPM will add the baseURL, which will stop things working if we don't strip it out
-        var base = new RegExp("^\/?" + getBaseUrl() + "\/");
+		// JSPM will add the baseURL, which will stop things working if we don't strip it out
+		var base = new RegExp("^\/?" + getBaseUrl() + "\/");
+		// For each file run the bundle method
+		eachAsync(this.files, function (file, i, next) {
+			var moduleExpression = !file.src.length ? file.orig.src[0].replace(/\.js/, "") : file.src[0].replace(base, "");
+			console.log("Bundling " + moduleExpression + " to " + file.dest);
+			jspm[bundle](moduleExpression, file.dest, options).then(next, next);
 
-        // For each file run the bundle method
-        eachAsync(this.files, function (el, i, next) {
-			var src = el.src[0].replace(base, "");
-
-            jspm.normalize(src).then(function (src) {
-                if (!src) {
-                    return next();
-                }
-
-                console.log("Bundling " + src + " to " + el.dest);
-                jspm[bundle](src, el.dest, options).then(next, next);
-            })
-
-        }, this.async());
+		}, this.async());
 	});
 };

--- a/tasks/jspm.js
+++ b/tasks/jspm.js
@@ -1,40 +1,40 @@
 "use strict";
 
 module.exports = function (grunt) {
-	var eachAsync = require("each-async");
+    var eachAsync = require("each-async");
 
-	// Setup JSPM
-	var jspm = require("jspm");
-	jspm.setPackagePath(".");
+    // Setup JSPM
+    var jspm = require("jspm");
+    jspm.setPackagePath(".");
 
-	// Geth the JSPM baseURL from package.json
-	var getBaseUrl = function () {
-		var pkgJson = grunt.file.readJSON("package.json");
+    // Geth the JSPM baseURL from package.json
+    var getBaseUrl = function () {
+        var pkgJson = grunt.file.readJSON("package.json");
 
-		if (pkgJson.jspm && pkgJson.jspm.directories && pkgJson.jspm.directories.baseURL) {
-			return pkgJson.jspm.directories.baseURL;
-		}
+        if (pkgJson.jspm && pkgJson.jspm.directories && pkgJson.jspm.directories.baseURL) {
+            return pkgJson.jspm.directories.baseURL;
+        }
 
-		return "";
-	};
+        return "";
+    };
 
-	grunt.registerMultiTask("jspm", "Bundle JSPM", function () {
-		var options = this.options({
-			sfx: true,
-			mangle: true,
-			minify: true
-		});
+    grunt.registerMultiTask("jspm", "Bundle JSPM", function () {
+        var options = this.options({
+            sfx: true,
+            mangle: true,
+            minify: true
+        });
 
-		var bundle = options.sfx ? "bundleSFX" : "bundle";
+        var bundle = options.sfx ? "bundleSFX" : "bundle";
 
-		// JSPM will add the baseURL, which will stop things working if we don't strip it out
-		var base = new RegExp("^\/?" + getBaseUrl() + "\/");
-		// For each file run the bundle method
-		eachAsync(this.files, function (file, i, next) {
-			var moduleExpression = !file.src.length ? file.orig.src[0].replace(/\.js/, "") : file.src[0].replace(base, "");
-			console.log("Bundling " + moduleExpression + " to " + file.dest);
-			jspm[bundle](moduleExpression, file.dest, options).then(next, next);
+        // JSPM will add the baseURL, which will stop things working if we don't strip it out
+        var base = new RegExp("^\/?" + getBaseUrl() + "\/");
+        // For each file run the bundle method
+        eachAsync(this.files, function (file, i, next) {
+            var moduleExpression = !file.src.length ? file.orig.src[0].replace(/\.js/, "") : file.src[0].replace(base, "");
+            console.log("Bundling " + moduleExpression + " to " + file.dest);
+            jspm[bundle](moduleExpression, file.dest, options).then(next, next);
 
-		}, this.async());
-	});
+        }, this.async());
+    });
 };


### PR DESCRIPTION
Adding support for jspm module expressions:

``` javascript
    jspm: {
            options: {
                sfx: false,
                minify: false,
                mangle: false
            },
            dist: {
                options: {
                    minify: true,
                    mangle: true
                },
                files: {
                    "build.js": "src/app - angular - angular-touch - angular-route",
                    "lib/main-lib.js": "lib/main.js"
                }
            }
        },
```
